### PR TITLE
Map relations to RO ids to be used in OWL translation.

### DIFF
--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <uri id="Imports Wizard Entry" name="http://purl.obolibrary.org/obo/ro/releases/2022-10-26/ro.owl" uri="http://purl.obolibrary.org/obo/ro.owl"/>
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/emapa/imports/ro_import.owl" uri="imports/ro_import.owl"/>
     <group id="Folder Repository, directory=, recursive=false, Auto-Update=false, version=2" prefer="public" xml:base=""/>
 </catalog>

--- a/src/ontology/emapa-edit.obo
+++ b/src/ontology/emapa-edit.obo
@@ -70445,40 +70445,48 @@ is_a: TS:0 ! Theiler stage
 [Typedef]
 id: attached_to
 name: attached_to
+xref: RO:0002371
 
 [Typedef]
 id: develops_from
 name: develops_from
 is_transitive: true
+xref: RO:0002202
 
 [Typedef]
 id: develops_in
 name: develops_in
+xref: RO:0002226
 
 [Typedef]
 id: ends_at
 name: ends_at
+xref: RO:0002493
 
 [Typedef]
 id: has_part
 name: has_part
 is_transitive: true
+xref: BFO:0000051
 
 [Typedef]
 id: is_a
 name: is_a
 is_transitive: true
+builtin: true
 
 [Typedef]
 id: located_in
 name: located_in
+xref: RO:0001025
 
 [Typedef]
 id: part_of
 name: part_of
 is_transitive: true
+xref: BFO:0000050
 
 [Typedef]
 id: starts_at
 name: starts_at
-
+xref: RO:0002489


### PR DESCRIPTION
This will make EMAPA more compatible with other OBO ontologies, by using relations from RO in its OWL file. This also eliminates problematic relation IRIs that don't resolve (see https://github.com/INCATools/ubergraph/issues/102).