### PR TITLE
Fix is_a stored as relations

### DIFF
--- a/src/ontology/emapa-edit.obo
+++ b/src/ontology/emapa-edit.obo
@@ -8307,8 +8307,8 @@ relationship: starts_at TS:18 ! TS18
 id: EMAPA:17073
 name: metencephalon alar plate
 namespace: anatomical_structure
+is_a: EMAPA:32915 ! hindbrain alar plate
 relationship: ends_at TS:28 ! TS28
-relationship: is_a EMAPA:32915 ! hindbrain alar plate
 relationship: part_of EMAPA:17072 ! metencephalon lateral wall
 relationship: starts_at TS:18 ! TS18
 
@@ -8352,8 +8352,8 @@ relationship: starts_at TS:18 ! TS18
 id: EMAPA:17078
 name: metencephalon basal plate
 namespace: anatomical_structure
+is_a: EMAPA:32914 ! hindbrain basal plate
 relationship: ends_at TS:28 ! TS28
-relationship: is_a EMAPA:32914 ! hindbrain basal plate
 relationship: part_of EMAPA:17072 ! metencephalon lateral wall
 relationship: starts_at TS:18 ! TS18
 
@@ -8404,8 +8404,8 @@ relationship: starts_at TS:18 ! TS18
 id: EMAPA:17084
 name: myelencephalon alar plate
 namespace: anatomical_structure
+is_a: EMAPA:32915 ! hindbrain alar plate
 relationship: ends_at TS:19 ! TS19
-relationship: is_a EMAPA:32915 ! hindbrain alar plate
 relationship: part_of EMAPA:17083 ! myelencephalon lateral wall
 relationship: starts_at TS:18 ! TS18
 
@@ -8439,8 +8439,8 @@ relationship: starts_at TS:18 ! TS18
 id: EMAPA:17088
 name: myelencephalon basal plate
 namespace: anatomical_structure
+is_a: EMAPA:32914 ! hindbrain basal plate
 relationship: ends_at TS:19 ! TS19
-relationship: is_a EMAPA:32914 ! hindbrain basal plate
 relationship: part_of EMAPA:17083 ! myelencephalon lateral wall
 relationship: starts_at TS:18 ! TS18
 
@@ -11835,8 +11835,8 @@ relationship: starts_at TS:20 ! TS20
 id: EMAPA:17553
 name: medulla oblongata alar plate
 namespace: anatomical_structure
+is_a: EMAPA:32915 ! hindbrain alar plate
 relationship: ends_at TS:26 ! TS26
-relationship: is_a EMAPA:32915 ! hindbrain alar plate
 relationship: part_of EMAPA:17552 ! medulla oblongata lateral wall
 relationship: starts_at TS:20 ! TS20
 
@@ -11869,8 +11869,8 @@ relationship: starts_at TS:20 ! TS20
 id: EMAPA:17557
 name: medulla oblongata basal plate
 namespace: anatomical_structure
+is_a: EMAPA:32914 ! hindbrain basal plate
 relationship: ends_at TS:28 ! TS28
-relationship: is_a EMAPA:32914 ! hindbrain basal plate
 relationship: part_of EMAPA:17552 ! medulla oblongata lateral wall
 relationship: starts_at TS:20 ! TS20
 
@@ -43984,8 +43984,8 @@ relationship: starts_at TS:17 ! TS17
 id: EMAPA:32914
 name: hindbrain basal plate
 namespace: anatomical_structure
+is_a: EMAPA:38287 ! basal plate
 relationship: ends_at TS:26 ! TS26
-relationship: is_a EMAPA:38287 ! basal plate
 relationship: part_of EMAPA:32912 ! hindbrain lateral wall
 relationship: starts_at TS:18 ! TS18
 
@@ -43993,8 +43993,8 @@ relationship: starts_at TS:18 ! TS18
 id: EMAPA:32915
 name: hindbrain alar plate
 namespace: anatomical_structure
+is_a: EMAPA:38286 ! alar plate
 relationship: ends_at TS:26 ! TS26
-relationship: is_a EMAPA:38286 ! alar plate
 relationship: part_of EMAPA:32912 ! hindbrain lateral wall
 relationship: starts_at TS:18 ! TS18
 
@@ -60188,8 +60188,8 @@ relationship: starts_at TS:28 ! TS28
 id: EMAPA:36989
 name: spinal cord dorsal column
 namespace: anatomical_structure
+is_a: EMAPA:38285 ! spinal cord column
 relationship: ends_at TS:28 ! TS28
-relationship: is_a EMAPA:38285 ! spinal cord column
 relationship: part_of EMAPA:35795 ! spinal cord white matter
 relationship: starts_at TS:28 ! TS28
 
@@ -60197,8 +60197,8 @@ relationship: starts_at TS:28 ! TS28
 id: EMAPA:36990
 name: spinal cord lateral column
 namespace: anatomical_structure
+is_a: EMAPA:38285 ! spinal cord column
 relationship: ends_at TS:28 ! TS28
-relationship: is_a EMAPA:38285 ! spinal cord column
 relationship: part_of EMAPA:35795 ! spinal cord white matter
 relationship: starts_at TS:28 ! TS28
 
@@ -60222,8 +60222,8 @@ relationship: starts_at TS:28 ! TS28
 id: EMAPA:36993
 name: spinal cord motor column
 namespace: anatomical_structure
+is_a: EMAPA:38285 ! spinal cord column
 relationship: ends_at TS:28 ! TS28
-relationship: is_a EMAPA:38285 ! spinal cord column
 relationship: part_of EMAPA:35792 ! spinal cord gray matter
 relationship: starts_at TS:28 ! TS28
 
@@ -60231,8 +60231,8 @@ relationship: starts_at TS:28 ! TS28
 id: EMAPA:36994
 name: spinal cord ventral column
 namespace: anatomical_structure
+is_a: EMAPA:38285 ! spinal cord column
 relationship: ends_at TS:28 ! TS28
-relationship: is_a EMAPA:38285 ! spinal cord column
 relationship: part_of EMAPA:35795 ! spinal cord white matter
 relationship: starts_at TS:28 ! TS28
 


### PR DESCRIPTION
Some is_a links were `relationship: is_a ` instead of `is_a: `.